### PR TITLE
Implemented refresh token support.

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const TOKENINFO_REQUEST_URL = process.env.TOKENINFO_REQUEST_URL || "/oauth2/v3/t
 const PERMITTED_REDIRECT_URLS = process.env.PERMITTED_REDIRECT_URLS ? process.env.PERMITTED_REDIRECT_URLS.split(",") : ["http://localhost:8181/auth/login"];
 
 const code2token = {};
+const refresh2personData = {};
 const authHeader2personData = {};
 const id_token2personData = {};
 
@@ -95,9 +96,16 @@ function validateAuthorizationHeader(header, res) {
 
 function validateAccessTokenRequest(req, res) {
   let success = true, msg;
-  if (req.body.grant_type !== "authorization_code") {
+  if (req.body.grant_type !== "authorization_code" && req.body.grant_type !== "refresh_token") {
     success = false;
-    msg = errorMsg("grant_type", "authorization_code", req.body.grant_type);
+    msg = errorMsg("grant_type", "authorization_code or refresh_token", req.body.grant_type);
+  }
+  if (req.body.grant_type === "refresh_token") {
+    let personData = refresh2personData[req.body.refresh_token];
+    if (personData === undefined) {
+      success = false;
+      msg = "invalid refresh token";
+    }
   }
   // if (!validateClientId(req.query.client_id, res)) {
   //   success = false;
@@ -146,6 +154,11 @@ function createToken(name, email, expires_in, client_state) {
     name: name
   };
   code2token[code] = token;
+  refresh2personData[refreshtoken] = {
+    name: name,
+    email: email,
+    expires_in: expires_in
+  };
   return code;
 }
 
@@ -185,7 +198,15 @@ app.get("/login-as", (req, res) => {
 
 app.post(ACCESS_TOKEN_REQUEST_PATH, (req, res) => {
   if (validateAccessTokenRequest(req, res)) {
-    const code = req.body.code;
+    let code = null;
+    if (req.body.grant_type === "refresh_token") {
+      const refresh = req.body.refresh_token;
+      const personData = refresh2personData[refresh];
+      code = createToken(personData.name, personData.email, personData.expires_in, null);
+      delete refresh2personData[refresh];
+    } else {
+      code = req.body.code;
+    }
     const token = code2token[code];
     if (token !== undefined) {
       console.log("access token response body: ", token);


### PR DESCRIPTION
Hi friend, I added some support for passing a refresh_token to the access token endpoint to get a new token after previous one has expired and not going through all the hoops, as I need to test this for my client app.

This fake server is great, I like not having to hit any live APIs while developing.

Cheers! :clap: :tada: 